### PR TITLE
tm1640.h header must be installed before the binaries can be successfully compiled

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -23,4 +23,4 @@ env.Install('/usr/bin', bin)
 env.Install('/usr/lib', lib)
 env.Install('/usr/include', 'src/libtm1640/tm1640.h')
 
-env.Alias('install', ['/usr/bin', '/usr/lib', '/usr/include'])
+env.Alias('install', ['/usr/include', '/usr/bin', '/usr/lib'])


### PR DESCRIPTION
When building the library on a clean machine the tm1640.h cannot be found:

> scons: Reading SConscript files ...
> scons: done reading SConscript files.
> scons: Building targets ...
> gcc -o src/main.o -c src/main.c
> src/main.c:17:20: fatal error: tm1640.h: No such file or directory
